### PR TITLE
fix: only the first two guests' field are filled

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,9 @@
     3. Click on `Load unpacked extension`
     4. Select the `build` folder.
 7. Have fun.
+
+# Testing
+
+- [Meldeschein Login](https://www.emeldeschein.de/oms/menu.xhtml?faces-redirect=true)
+
+

--- a/src/js/main/content_scripts/scripts/fill_meldeschein.js
+++ b/src/js/main/content_scripts/scripts/fill_meldeschein.js
@@ -15,10 +15,15 @@ chrome.runtime.onMessage.addListener(
     (request, sender, sendResponse) => {
         console.log(request.data);
         for (const [key, value] of Object.entries(request.data)) {
+            
+            const htmlElement = document.getElementById(key);
+            if(htmlElement == null) {
+                console.log(`no htmlElement with id="${key}" found`)
+                continue;
+            }
 
             if(typeof value === "object"){
 
-                const htmlElement = document.getElementById(key);
                 htmlElement.value = value.value;
 
                 const changeEvent = document.createEvent("HTMLEvents");
@@ -27,7 +32,7 @@ chrome.runtime.onMessage.addListener(
 
             } else {
 
-                document.getElementById(key).value = value;
+                htmlElement.value = value;
 
             }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Meldeschein Autofill",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "manifest_version": 3,
   "options_ui": {
     "page": "options.html",


### PR DESCRIPTION
## Problem
Some of the meldeschein form's fields were removed.
This caused the fill script to run into a NullPointer that stopped the filling of all subsequent fields.

## Solution
The fill script ignores fields that are missing.
They are not removed from the code because they might be added again in the future.